### PR TITLE
Update BigQuery release notes for June 2025 in Japanese with URLs

### DIFF
--- a/bigquery/2025-06.md
+++ b/bigquery/2025-06.md
@@ -1,0 +1,48 @@
+## BigQuery
+
+- [2025-06-16: GA]: BigQuery ML で、ARIMA_PLUS_XREG 多変量時系列モデルで利用可能な TIME_SERIES_ID_COL オプションを使用して、一度に複数の時系列を予測できるようになりました。この機能は [多変量モデルによる複数時系列の予測チュートリアル](https://cloud.google.com/bigquery/docs/arima-plus-xreg-multiple-time-series-forecasting-tutorial)でお試しいただけます。
+- [2025-06-16: GA]: SQL を使用して BigQuery データセットとテーブル上の [IAM タグ](https://cloud.google.com/bigquery/docs/tags)を管理できるようになりました。
+- [2025-06-16: Preview]: BigQuery 移行評価が、[Cloudera と Apache Hadoop](https://cloud.google.com/bigquery/docs/migration-assessment#hadoop-cloudera) を使用するワークフローで利用できるようになりました。
+- [2025-06-16: GA]: [Merchant Center ベストセラーレポート](https://cloud.google.com/bigquery/docs/merchant-center-best-sellers-schema)はマルチクライアントアカウント (MCA) をサポートします。MCA をお持ちの場合は、aggregator_id を使用してテーブルを照会できます。BestSellersEntityProductMapping テーブルは、ベストセラーエンティティをサブアカウントの在庫内の商品にマッピングします。これにより、ベストセラー商品の統合ビューが提供され、商品データと結合してより詳細なインサイトを得ることができます。
+- [2025-06-16: GA]: BigQuery は、次の Gemini 拡張 SQL 翻訳機能を提供するようになりました。
+    - [Gemini ベースの設定 YAML ファイル](https://cloud.google.com/bigquery/docs/config-yaml-translation#ai_yaml_guidelines)を作成して、バッチまたはインタラクティブな SQL 翻訳の AI 提案を生成します。
+    - バッチ SQL 翻訳を行った後、[コードタブ](https://cloud.google.com/bigquery/docs/batch-sql-translator#code-tab)と[設定タブ](https://cloud.google.com/bigquery/docs/batch-sql-translator#configuration_tab)を使用して、Gemini ベースの提案を含む翻訳出力を確認します。
+- [2025-06-16: Preview]: インタラクティブな SQL 翻訳を行う際に、[Gemini 拡張翻訳ルールを作成して適用](https://cloud.google.com/bigquery/docs/interactive-sql-translator#create-apply-rules)し、SQL 入力をカスタマイズします。
+- [2025-06-12: Preview]: BigQuery でダークテーマが[プレビュー版](https://cloud.google.com/products#product-launch-stages)で利用可能になりました。ダークテーマを有効にするには、Google Cloud コンソールで [設定とユーティリティ] > [設定] をクリックします。ナビゲーションメニューで [外観] をクリックし、カラーテーマを選択して [保存] をクリックします。
+- [2025-06-11: Preview]: 次の GoogleSQL 関数が[プレビュー版](https://cloud.google.com/products#product-launch-stages)で利用可能になりました。
+    - [ARRAY_FIRST 関数](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_first)は、入力配列の最初の要素を返します。
+    - [ARRAY_LAST 関数](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_last)は、入力配列の最後の要素を返します。
+    - [ARRAY_SLICE 関数](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_slice)は、入力配列から連続する要素を含む配列を返します。
+- [2025-06-10: GA]: BigQuery 用の [ODBC ドライバー](https://cloud.google.com/bigquery/docs/reference/odbc-jdbc-drivers#odbc_release_3121009)の更新バージョンが利用可能になりました。
+- [2025-06-10: GA]: [サポートされている Gemini モデル](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/supported-models)では、[ML.GENERATE_TEXT](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-generate-text#provisioned-throughput)および [AI.GENERATE](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-ai-generate#provisioned-throughput) 関数で [Vertex AI プロビジョニング済みスループット](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/overview)を使用して、リクエストに一貫した高スループットを提供できるようになりました。
+- [2025-06-09: GA]: Java 用 [google-cloud-bigquery](https://github.com/googleapis/java-bigquery) [2.51.0](https://github.com/googleapis/java-bigquery/compare/v2.50.1...v2.51.0) がリリースされました。
+    - 機能: ジョブ作成モード GA ([#3804](https://github.com/googleapis/java-bigquery/issues/3804))
+    - 機能: データセットのきめ細かい ACL のサポート ([#3803](https://github.com/googleapis/java-bigquery/issues/3803))
+    - 依存関係が更新されました。
+- [2025-06-09: GA]: BigQuery マネージドストレージにデータを移行する代わりに、マテリアライズドビューで [Iceberg 外部テーブル](https://cloud.google.com/bigquery/docs/materialized-views-create#iceberg)を参照できるようになりました。
+- [2025-06-04: Unsupported]: default_sql_dialect_option と query_runtime の[組織レベルの設定](https://cloud.google.com/bigquery/docs/default-configuration)はサポートされていません。
+- [2025-06-03: Preview]: [BigQuery 高度なランタイム](https://cloud.google.com/bigquery/docs/advanced-runtime)を使用して、クエリ実行時間とスロット使用量を改善できるようになりました。
+- [2025-06-03: GA]: Apache Iceberg 用の BigQuery テーブルは、BigQuery の Apache Iceberg 用の [BigLake テーブル](https://cloud.google.com/bigquery/docs/iceberg-tables)に名前が変更されました。
+- [2025-06-03: GA]: BigQuery メタストアは [BigLake メタストア](https://cloud.google.com/bigquery/docs/about-blms)に名前が変更され、[一般提供](https://cloud.google.com/products#product-launch-stages)が開始されました。以前 BigLake メタストアとして知られていた機能は、BigLake メタストア (クラシック) に名前が変更されました。
+- [2025-06-02: GA]: Node.js 用 [@google-cloud/bigquery](https://github.com/googleapis/nodejs-bigquery) [8.1.0](https://github.com/googleapis/nodejs-bigquery/compare/v8.0.0...v8.1.0) がリリースされました。
+    - 機能: ジョブ作成モード GA ([#1480](https://github.com/googleapis/nodejs-bigquery/issues/1480))
+    - 機能: ジョブごとの予約割り当てのサポート ([#1477](https://github.com/googleapis/nodejs-bigquery/issues/1477))
+- [2025-06-02: GA]: Go 用 [bigquery/storage/apiv1beta1](https://github.com/googleapis/google-cloud-go/tree/main/bigquery/storage/apiv1beta1) [1.69.0](https://github.com/googleapis/google-cloud-go/compare/bigquery/v1.68.0...bigquery/v1.69.0) がリリースされました。
+    - 機能: Analytics Hub と Marketplace の統合のサポートを追加
+    - 機能: Listing リソースへの allow_only_metadata_sharing の追加
+    - 機能: Listing および Subscription リソースへの CommercialInfo メッセージの追加
+    - 機能: DeleteListingRequest および RevokeSubscriptionRequest への delete_commercial および revoke_commercial の追加
+    - 機能: Subscription リソースへの DestinationDataset の追加
+    - 機能: SharedResource メッセージへの routine フィールドの追加
+    - 機能: データセットの表示および更新モードのサポートを追加 ([#12290](https://github.com/googleapis/google-cloud-go/issues/12290))
+    - 機能: ジョブ作成モード GA ([#12225](https://github.com/googleapis/google-cloud-go/issues/12225))
+- [2025-06-02: GA]: Python 用 [google-cloud-bigquery](https://github.com/googleapis/python-bigquery) [3.34.0](https://github.com/googleapis/python-bigquery/compare/v3.33.0...v3.34.0) がリリースされました。
+    - 機能: ジョブ作成モード GA ([#2190](https://github.com/googleapis/python-bigquery/issues/2190))
+    - バグ修正: すべての依存関係を更新 ([#2184](https://github.com/googleapis/python-bigquery/issues/2184))
+    - ドキュメントが更新されました。
+- [2025-06-02: Preview]: ナビゲーションメニューで、[設定] に移動し、[設定](https://cloud.google.com/bigquery/docs/bigquery-web-ui#navigation_menu)を選択して、選択したプロジェクトまたは組織内のユーザー向けに BigQuery Studio エクスペリエンスをカスタマイズできるようになりました。これは、ユーザーインターフェイス要素を表示または非表示にすることで実現されます。
+- [2025-06-02: GA]: BigQuery は、[承認済みビュー](https://cloud.google.com/bigquery/docs/authorized-views)、[承認済みルーチン](https://cloud.google.com/bigquery/docs/authorized-routines)、および [Cloud リソース接続](https://cloud.google.com/bigquery/docs/create-cloud-resource-connection)を使用した [Spanner 外部データセット](https://cloud.google.com/bigquery/docs/spanner-external-datasets)の使用をサポートするようになりました。
+- [2025-06-02: Preview]: [CREATE EXTERNAL TABLE](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_external_table_statement) および [LOAD DATA](https://cloud.google.com/bigquery/docs/reference/standard-sql/load-statements) ステートメントが、次のオプションを[プレビュー版](https://cloud.google.com/products#product-launch-stages)でサポートするようになりました。
+    - time_zone: データのロード時に使用するタイムゾーンを指定します。
+    - date_format、datetime_format、time_format、および timestamp_format: ソースファイルでの日付と時刻の値のフォーマット方法を定義します。
+- [2025-06-02: GA]: BigQuery コンソールの [ようこそ] タブで、Spark ノートブックの基本を説明し、BigQuery の[サーバーレス Spark](https://cloud.google.com/bigquery/docs/use-spark) を紹介する [Apache Spark デモノートブック](https://cloud.google.com/bigquery/docs/bigquery-web-ui#run_spark_notebook_demo_guide)を試すことができるようになりました。


### PR DESCRIPTION
This commit updates the BigQuery release notes for June 2025:
- Translated content to Japanese.
- Added relevant URLs for each announcement.