### PR TITLE
Update Vertex AI release notes for June 2025 to Japanese

### DIFF
--- a/vertexai/2025-06.md
+++ b/vertexai/2025-06.md
@@ -1,0 +1,27 @@
+## Generative AI on Vertex AI (Vertex AI 上の生成 AI)
+
+- [2025-06-17: GA]: Gemini 2.5 Flash および Gemini 2.5 Pro が API と Vertex AI Studio を使用して一般提供開始されました。https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
+- [2025-06-17: Preview]: Gemini 2.5 Flash-Lite が API と Vertex AI Studio の両方でプレビュー提供開始されました。https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-lite
+- [2025-06-17: Private GA]: Live API が API と Vertex AI Studio でプライベート一般提供として開始されました。https://cloud.google.com/vertex-ai/generative-ai/docs/live-api
+- [2025-06-17: 情報]: プレビューエンドポイントの提供状況と削除：既存のすべての Gemini 2.5 Flash および Pro プレビューエンドポイントは、2025年7月15日まで現在のプレビュー価格で引き続き利用可能です。この日以降、これらのプレビューエンドポイントはシャットダウンされます。https://cloud.google.com/vertex-ai/docs/release-notes#June_17_2025
+- [2025-06-17: 情報]: Gemini 2.5 Flash GA の更新された価格が調整されます。https://cloud.google.com/vertex-ai/docs/release-notes#June_17_2025
+- [2025-06-17: 情報]: プロビジョンドスループット (PT): 新規の PT 購入はすべて GA エンドポイントのみとなります。既存の PT は2025年7月15日までに GA エンドポイントに移行してください。https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/purchase-provisioned-throughput#change-order
+- [2025-06-17: 情報]: 更新されたプレビューエンドポイント：2025年6月19日より、gemini-2.5-flash-preview-04-17 は05-20にリリースされた Gemini 2.5 Flash モデルバージョン（GA）を提供します。同様に、gemini-2.5-pro-preview-05-06 および 03-25 は06-05にリリースされた Gemini 2.5 Pro モデルバージョン（GA）を提供します。https://cloud.google.com/vertex-ai/docs/release-notes#June_17_2025
+- [2025-06-16: Preview]: Vertex AI 上の DeepSeek API サービスがプレビュー段階です。https://console.cloud.google.com/vertex-ai/publishers/deepseek-ai/model-garden/deepseek-r1-0528-maas
+- [2025-06-11: Preview]: Imagen 4 のパブリックプレビューモデルが imagen-4.0-generate-preview-06-06, imagen-4.0-fast-generate-preview-06-06, imagen-4.0-ultra-generate-preview-06-06 に更新されました。https://cloud.google.com/vertex-ai/generative-ai/docs/models#preview-imagen-models
+- [2025-06-11: 情報]: imagen-4.0-ultra-generate-exp-05-20 および imagen-4.0-generate-preview-05-20 から2025年7月7日までに移行してください。https://cloud.google.com/vertex-ai/docs/release-notes#June_11_2025
+- [2025-06-09: GA]: Gemini API：Gemini API の logprobs および response_logprobs パラメータが一般提供開始されました。https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#logprobs
+- [2025-06-05: Preview]: Gemini 2.5 Pro のパブリックプレビュー版が gemini-2.5-pro-preview-06-05 に更新され、思考のサポートが拡張されました。https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro
+- [2025-06-03: 情報]: Model Garden に DeepSeek-R1-0528 バリアントが追加されました。https://console.cloud.google.com/vertex-ai/publishers/deepseek-ai/model-garden/deepseek-r1
+- [2025-06-03: 情報]: Model Garden: PEFT docker を使用した Gemma 3 UI ファインチューニングが追加されました。https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemma3
+- [2025-06-03: 情報]: Model Garden: PEFT docker を使用した Qwen 2.5 ファインチューニングノートブックが追加されました。https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_garden/model_garden_pytorch_qwen2_5_finetuning.ipynb
+- [2025-06-03: 情報]: Model Garden: Axolotl docker を使用した Qwen 3 ファインチューニングノートブックが追加されました。https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_garden/model_garden_axolotl_qwen3_finetuning.ipynb
+- [2025-06-03: 情報]: Model Garden: Llama 3.3, Llama 3.1, Gemma 3, Gemma 2 ファインチューニングノートブックに評価サービスとして lm-evaluation-harness が追加されました。https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_garden/model_garden_pytorch_llama3_3_finetuning.ipynb
+
+## Vertex AI
+
+- [2025-06-10: 情報]: Vector Search のカスタム制約と組織ポリシー。組織ポリシーサービスでカスタム制約を使用して、Vector Search のインデックスとインデックスエンドポイントの特定のフィールドをより詳細に制御できます。https://cloud.google.com/vertex-ai/docs/vector-search/custom-constraints
+
+## Vertex AI Workbench
+
+- [2025-06-10: Preview]: プレビューで利用可能：Vertex AI Workbench インスタンスで予約を消費できます。https://cloud.google.com/vertex-ai/docs/workbench/instances/reservations


### PR DESCRIPTION
Translated the content of vertexai/2025-06.md to Japanese based on user request.

This includes translating the descriptions of new features, updates, and announcements related to Vertex AI and Generative AI on Vertex AI for June 2025.